### PR TITLE
minor: Fix run_docker.sh running CI pipeline

### DIFF
--- a/.github/workflows/bash_scripts.yml
+++ b/.github/workflows/bash_scripts.yml
@@ -38,7 +38,9 @@ jobs:
           echo -en "machine github.com\nlogin JanMate\npassword ${{ secrets.JM_GITHUB_TOKEN }}" > ~/.netrc
       
       - name: Run all shell scripts in this repo
-        run: find . -type f -and -name "*.sh" -exec bash -c {} \;
+        run: |
+          find . -type f -and \( -name "*.sh" -and -not -name "run_docker.sh" \) -exec bash -c {} \;
+          ./run_docker.sh "jmatejka" "{{ secrets.JM_DOCKER_TOKEN }}"
       
       - name: Clean git global config due to git clone script
         run: |


### PR DESCRIPTION
It exclude run_docker.sh from general shell scripts running and adds it username and password args.